### PR TITLE
Tooltip/popover: Fix auto placement to use viewport

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -192,13 +192,12 @@
 
       if (autoPlace) {
         var orgPlacement = placement
-        var $container   = this.options.container ? $(this.options.container) : this.$element.parent()
-        var containerDim = this.getPosition($container)
+        var viewportDim = this.getPosition(this.$viewport)
 
-        placement = placement == 'bottom' && pos.bottom + actualHeight > containerDim.bottom ? 'top'    :
-                    placement == 'top'    && pos.top    - actualHeight < containerDim.top    ? 'bottom' :
-                    placement == 'right'  && pos.right  + actualWidth  > containerDim.width  ? 'left'   :
-                    placement == 'left'   && pos.left   - actualWidth  < containerDim.left   ? 'right'  :
+        placement = placement == 'bottom' && pos.bottom + actualHeight > viewportDim.bottom ? 'top'    :
+                    placement == 'top'    && pos.top    - actualHeight < viewportDim.top    ? 'bottom' :
+                    placement == 'right'  && pos.right  + actualWidth  > viewportDim.width  ? 'left'   :
+                    placement == 'left'   && pos.left   - actualWidth  < viewportDim.left   ? 'right'  :
                     placement
 
         $tip


### PR DESCRIPTION
Currently, auto placement is using the container dimensions (if provided) or the element's parent to determine where to open the tooltip:
```javascript
var $container   = this.options.container ? $(this.options.container) : this.$element.parent()
var containerDim = this.getPosition($container)
```
This is quite broken in fact, because the parent element could be just a small div outside the element for example, leading in a totally random placement (placing the tooltip on top even if there's no room). And the container can also be outside of the viewport.

This fix simply uses the viewport instead, that's the purpose of the viewport actually, to position the tooltip.
So the auto placement should use it to find where there's more room.
By default this is body, which is good.